### PR TITLE
Do not start ssl in initialize

### DIFF
--- a/inspec.yml
+++ b/inspec.yml
@@ -5,6 +5,6 @@ copyright: Alex Pop
 copyright_email: not-given-here@example.com
 license: Apache 2 license
 summary: InSpec profile providing an ssl_certificate resource and sample controls
-version: 0.2.0
+version: 0.3.0
 supports:
   - inspec: '~> 1.0'


### PR DESCRIPTION
With this change, the resource no longer starts the ssl test in initialize. Only when a property is requested.

This makes the `inspec check` quick.