### PR TITLE
return certificate file path in `to_s`

### DIFF
--- a/libraries/ssl_certificate.rb
+++ b/libraries/ssl_certificate.rb
@@ -135,6 +135,8 @@ class SslCertificate < Inspec.resource(1)
   end
 
   def to_s
+    return @path if @path
+
     p = (@port == 443 ? '' : ":#{@port}")
     return "ssl_certificate for '#{@host}#{p}'"
   end


### PR DESCRIPTION
Minor fix. When referencing a certificate file, `to_s` returns just `:` - an invalid string given the context. This change returns the `@path` value instead.